### PR TITLE
npm script: remove qualified path to node_modules/.bin

### DIFF
--- a/.idea/libraries/react_app_boilerplate_node_modules.xml
+++ b/.idea/libraries/react_app_boilerplate_node_modules.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="react-app-boilerplate node_modules" type="javaScript">
+    <properties>
+      <option name="frameworkName" value="node_modules" />
+      <sourceFilesUrls>
+        <item url="file://$PROJECT_DIR$/node_modules" />
+      </sourceFilesUrls>
+    </properties>
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/node_modules" />
+    </CLASSES>
+    <SOURCES />
+  </library>
+</component>

--- a/app/App.js
+++ b/app/App.js
@@ -1,1 +1,1 @@
-import React, { Component } from 'react';import {render} from 'react-dom';class App extends Component {  render(){    return (      <h1>Hello World</h1>    );  }}render(<App />, document.getElementById('root'));
+import React, {Component} from 'react';import {render} from 'react-dom';class App extends Component {  render(){    return (      <h1>Hello World</h1>    );  }}render(<App />, document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Cássio Zen",
   "license": "ISC",
   "scripts": {
-    "start": "node_modules/.bin/webpack-dev-server --progress",
+    "start": "webpack-dev-server --progress",
     "build": "NODE_ENV=production node_modules/.bin/webpack -p --progress --colors"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "babel-loader": "~6.0.*",
     "babel-preset-es2015": "~6.0.*",
     "babel-preset-react": "~6.0.*",
+    "react-addons-update": "^0.14.7",
     "webpack": "~1.12.*",
-    "webpack-dev-server": "~1.12.*"
+    "webpack-dev-server": "~1.12.*",
+    "whatwg-fetch": "^0.11.0"
   },
   "dependencies": {
     "react": "~0.14.*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,5 @@
 var webpack = require('webpack');
 
-/*
- * Default webpack configuration for development
- */
 var config = {
   devtool: 'eval-source-map',
   entry:  __dirname + "/app/App.js",
@@ -11,35 +8,36 @@ var config = {
     filename: "bundle.js"
   },
   module: {
-    loaders: [{
-      test: /\.jsx?$/,
-      exclude: /node_modules/,
-      loader: 'babel',
-      query: {
-        presets: ['es2015','react']
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015','react']
+        }
       }
-    }]
+    ]
   },
   devServer: {
     contentBase: "./public",
     colors: true,
     historyApiFallback: true,
     inline: true
-  },
-}
+  }
+};
 
-/*
- * If bundling for production, optimize output
- */
 if (process.env.NODE_ENV === 'production') {
   config.devtool = false;
   config.plugins = [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({comments: false}),
     new webpack.DefinePlugin({
-      'process.env': {NODE_ENV: JSON.stringify('production')}
+      'process.env': {
+        NODE_ENV: JSON.stringify('production')
+      }
     })
   ];
-};
+}
 
 module.exports = config;


### PR DESCRIPTION
I thought this would be cleaner; we don't have to qualify paths to node binaries in `package.json`.
